### PR TITLE
Place window initially at true top-left

### DIFF
--- a/src/core/place.c
+++ b/src/core/place.c
@@ -35,6 +35,8 @@
 #include <math.h>
 #include <stdlib.h>
 
+//#define USE_CENTER_TILE_RECT
+
 typedef enum
 {
   META_LEFT,
@@ -454,6 +456,7 @@ topmost_cmp (gconstpointer a, gconstpointer b)
     return 0;
 }
 
+#ifdef USE_CENTER_TILE_RECT
 static void
 center_tile_rect_in_area (MetaRectangle *rect,
                           MetaRectangle *work_area)
@@ -471,6 +474,7 @@ center_tile_rect_in_area (MetaRectangle *rect,
   fluff = (work_area->height % (rect->height+1)) / 3;
   rect->y = work_area->y + fluff;
 }
+#endif
 
 /* Find the leftmost, then topmost, empty area on the workspace
  * that can contain the new window.
@@ -534,7 +538,12 @@ find_first_fit (MetaWindow         *window,
                                                  logical_monitor,
                                                  &work_area);
 
+#ifdef USE_CENTER_TILE_RECT
   center_tile_rect_in_area (&rect, &work_area);
+#else
+  rect.x = work_area.x;
+  rect.y = work_area.y;
+#endif
 
   if (meta_rectangle_contains_rect (&work_area, &rect) &&
       !rectangle_overlaps_some_window (&rect, windows))


### PR DESCRIPTION
To me the current window placement in mutter is not what I want. I often have windows of different sizes on the same workspace. Often I occupy the left part of the screen with perhaps two or three terminal windows and then occupy the right part with some editor. My work-flow is to first open the terminals and then the window. With the current window placement the first terminal is placed using the "center tile rect in area" algorithm which basically places the window in the top-left corner of the screen, but with a padding. The padding is calculated by evenly distributing the remaining space in the case that the full screen would be occupied by windows of the same size. With this default placement I always end up with manually moving the first terminal window to the "true" top-left corner.

This commit disables the "center tile rect in area" algorithm and instead places the first window on each screen at the "true" top-left.

Do you guys see the use-case of having this other placement algorithm? Let's discuss!

Perhaps it shall be controlled by some configuration option. Having the following options:
- Place initial window using the "center tile rect" algorithm.
- Place intial window in the top-left corner.
- ...
