### PR TITLE
Fix direction logic for MOTION_{UP,DOWN}

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -585,7 +585,6 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
     * Notify the compositor that the active workspace is changing.
     */
    comp = meta_display_get_compositor (workspace->display);
-   direction = 0;
 
    current_space = meta_workspace_index (old);
    new_space     = meta_workspace_index (workspace);
@@ -613,22 +612,22 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
 
    if (layout1.current_row < layout2.current_row)
      {
-       if (!direction)
-         direction = META_MOTION_DOWN;
+       if (direction == META_MOTION_LEFT)
+         direction = META_MOTION_DOWN_LEFT;
        else if (direction == META_MOTION_RIGHT)
          direction = META_MOTION_DOWN_RIGHT;
        else
-         direction = META_MOTION_DOWN_LEFT;
+         direction = META_MOTION_DOWN;
      }
 
    if (layout1.current_row > layout2.current_row)
      {
-       if (!direction)
-         direction = META_MOTION_UP;
+       if (direction == META_MOTION_LEFT)
+         direction = META_MOTION_UP_LEFT;
        else if (direction == META_MOTION_RIGHT)
          direction = META_MOTION_UP_RIGHT;
        else
-         direction = META_MOTION_UP_LEFT;
+         direction = META_MOTION_UP;
      }
 
    meta_workspace_manager_free_workspace_layout (&layout1);


### PR DESCRIPTION
The logic in meta_workspace_activate_with_focus() which computes 'direction' is broken and will never return META_MOTION_{UP,DOWN}. (This may be dependent on how the code is compiled.) In pseudo-code:
```
direction = 0;
if (left) direction = LEFT;
if (right) direction = RIGHT;
if (down) {
  if (!direction)  // <-- BUG HERE
    direction = DOWN;
  else if (direction = RIGHT)
    direction = DOWN_RIGHT;
  else
    direction = DOWN_LEFT;
}
if (up) { /* same */ }
```
The code looks like it should work: if neither left nor right triggers, 'direction' should be zero, we take the "if (!direction)" branch, and the final value is DOWN. But what actually happens is that neither branch is taken, we fall through to the "else", and the final value is DOWN_LEFT. The same thing happens in the UP section.

The problem is that 'direction' isn't an int, it's an enum (specifically MetaMotionDirection), and zero isn't a valid enum value. I suspect the bug occurs because aggressively optimized compilers use the fact that MetaMotionDirection can't be zero to delete unnecessary code. That is:

> MetaMotionDirection can't have the value zero
> so (bool)MetaMotionDirection is always true
> direction is a MetaMotionDirection
> so !direction is always false
> so this compiler can elide "if (!direction)"

This would also explain how the bug occurred: it likely *did* work correctly when it was written, and might still work under some compilers and/or compilation settings.